### PR TITLE
Fix/json input

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -57,8 +57,19 @@ on:
         required: false
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      list-of-params: ${{ steps.setVariables.outputs.list-of-params }}
+      snap-artifact-name: ${{ inputs.snap-name }}-${{ fromJson(steps.setVariables.outputs.list-of-params)[0] }}
+    steps:
+      - id: setVariables
+        run: echo "list-of-params=$input" >> $GITHUB_OUTPUT
+        env:
+          input: ${{ inputs.ubuntu-image }}
   build:
-    runs-on: '${{ inputs.ubuntu-image }}'
+    needs: setup
+    runs-on: "${{ fromJSON(needs.setup.outputs.list-of-params) }}"
     outputs:
       snap-file: ${{ steps.build-snap.outputs.snap }}
       upload-branch-name: ${{ steps.branch-name.outputs.BRANCH_NAME }}
@@ -68,7 +79,7 @@ jobs:
       with:
         ref: '${{ inputs.branch-name }}'
     - name: Build snap
-      uses: snapcore/action-build@v1
+      uses: canonical/action-build@v1
       id: build-snap
       env:
         SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS : '${{ inputs.enable-experimental-extensions-env }}'
@@ -83,18 +94,18 @@ jobs:
     - name: Upload snap artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.snap-name }}-${{ steps.branch-name.outputs.BRANCH_NAME }}
+        name: ${{ needs.setup.outputs.snap-artifact-name }}-${{ steps.branch-name.outputs.BRANCH_NAME }}
         path: ${{ steps.build-snap.outputs.snap }}
         retention-days: 14
   
   test:
-    runs-on: '${{ inputs.ubuntu-image }}'
-    needs: build
+    runs-on: "${{ fromJSON(needs.setup.outputs.list-of-params) }}"
+    needs: [setup, build]
     steps:
       - name: Download snap artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.snap-name }}-${{needs.build.outputs.upload-branch-name}}
+          name: ${{ needs.setup.outputs.snap-artifact-name }}-${{needs.build.outputs.upload-branch-name}}
           path: ${{ inputs.snapcraft-build-path }}
       - name: Install snap
         env:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -64,7 +64,14 @@ jobs:
       snap-artifact-name: ${{ inputs.snap-name }}-${{ fromJson(steps.setVariables.outputs.list-of-params)[0] }}
     steps:
       - id: setVariables
-        run: echo "list-of-params=$input" >> $GITHUB_OUTPUT
+        run: |
+          if jq -e . >/dev/null 2>&1 <<<"$input"; then
+              echo "list-of-params=$input" >> $GITHUB_OUTPUT
+          else
+              input_as_json="[\"$input\"]"
+              echo "ubuntu-image input is not a json, formatting it into a json list: $input_as_json."
+              echo "list-of-params=$input_as_json" >> $GITHUB_OUTPUT
+          fi
         env:
           input: ${{ inputs.ubuntu-image }}
   build:


### PR DESCRIPTION
By taking json input in ubuntu-image, we can handle the self hosted Canonical runners that are json lists and not a simple string.

The workflow was tested successfully with json and simple string:
- [simple string](https://github.com/canonical/turtlebot3c-snap/actions/runs/11011078589/job/30581561691)
- [json](https://github.com/canonical/turtlebot3c-snap/actions/runs/11010975953/job/30581975590)