### PR TITLE
fix(artifact-name): artifact names now contain the name of the branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,10 +82,16 @@ jobs:
           snapcraft-channel: '${{ inputs.snapcraft-channel }}'
           snapcraft-args: '${{ inputs.snapcraft-args }}'
 
+      - name: Find out the branch name
+        id: get-branch
+        run: |
+          branch_name="${{ inputs.git-ref }}"
+          echo "branch_name=${branch_name//[\/-]/_}" >> "$GITHUB_OUTPUT"
+
       - name: Set unique artifact name
         id: artifact-unique-name
         run: |
-          echo "artifact-name=workflow-build-snap-$(basename -s .snap ${{ steps.build-snap.outputs.snap }})" >> "$GITHUB_OUTPUT"
+          echo "artifact-name=workflow-build-snap-$(basename -s .snap ${{ steps.build-snap.outputs.snap }})-${{ steps.get-branch.outputs.branch_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Upload snap artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -80,6 +80,7 @@ jobs:
     with:
       lxd-image: ${{ inputs.lxd-image }}
       runs-on: ${{ inputs.runs-on }}
+      git-ref: ${{ inputs.git-ref }}
       snap-install-args: ${{ inputs.snap-install-args }}
       snap-test-script: ${{ inputs.snap-test-script }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,11 @@ on:
         description: The runner(s) to use.
         required: false
         type: string
+      git-ref:
+        default: '${{ github.ref }}'
+        description: The branch used to build the snap.
+        required: false
+        type: string
       snap-install-args:
         default: "--dangerous"
         description: The argument to pass to snap install.
@@ -47,14 +52,20 @@ jobs:
 
       - name: Find out the arch
         id: get-arch
-        run: echo "arch=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "arch=$(dpkg --print-architecture)" >> "$GITHUB_OUTPUT"
+
+      - name: Find out the branch name
+        id: get-branch
+        run: |
+          branch_name="${{ inputs.git-ref }}"
+          echo "branch_name=${branch_name//[\/-]/_}" >> "$GITHUB_OUTPUT"
 
       - name: Download snap artifact(s)
         uses: actions/download-artifact@v4
         with:
           path: .
-          pattern: 'workflow-build-snap-*${{ steps.get-arch.outputs.arch }}*'
-          # merge-multiple: true
+          pattern: 'workflow-build-snap-*${{ steps.get-arch.outputs.arch }}*-${{ steps.get-branch.outputs.branch_name }}'
 
       - name: Retrieve snap file
         id: get-snap-file

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The `test` uses the following subset of options from the `snap` workflow:
 
 - `lxd-image`
 - `runs-on`
+- `git-ref`
 - `snap-install-args`
 - `snap-test-script`
 


### PR DESCRIPTION
Adds the name of the branch to the name of the artifact to make it as unique as possible.

I also tried to add `github.run_id`. Unfortunately, [the id is shared between all the steps of a workflow](https://github.com/canonical/turtlebot3c-snap/actions/runs/12792090014/attempts/3).

I also tried to add `github.job`. Unfortunately, [the `job` gives the first parent job name which is `build` for all the steps](https://github.com/canonical/turtlebot3c-snap/actions/runs/12792090014/attempts/4).


The final working result can be observed at: https://github.com/canonical/turtlebot3c-snap/actions/runs/12792090014/job/35717987108