### PR TITLE
fix(keep_alive): adjust permissions to read content

### DIFF
--- a/.github/workflows/keepalive.yaml
+++ b/.github/workflows/keepalive.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
Defining a permission seems to overwrite the default value of other permission (see https://github.com/actions/checkout/issues/254 and https://github.com/actions/checkout/issues/445)

This is causing issues with private repo:

Before: https://github.com/canonical/ros_snapd/actions/runs/12866431569
```
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +1623941631cbdf9992798da3b3e71cacb6e48e37:refs/remotes/origin/jazzy
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/canonical/ros_snapd/' not found
  The process '/usr/bin/git' failed with exit code 128
  Waiting 13 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +1623941631cbdf9992798da3b3e71cacb6e48e37:refs/remotes/origin/jazzy
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/canonical/ros_snapd/' not found
  The process '/usr/bin/git' failed with exit code 128
  Waiting 19 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +1623941631cbdf9992798da3b3e71cacb6e48e37:refs/remotes/origin/jazzy
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/canonical/ros_snapd/' not found
  Error: The process '/usr/bin/git' failed with exit code 128
```
After: https://github.com/canonical/ros_snapd/actions/runs/12866742457