### PR TITLE
add channel-risk-sync-monitor

### DIFF
--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -122,19 +122,19 @@ jobs:
         if: steps.revision.outputs.is-newer == '1'
         id: date
         env:
-          SNAP_APIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
+          SNAP_ASPIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
         run: |
-          PUB_DATE="$(snap info ${{ steps.parse.outputs.snap-name }} | yq '.channels[env(SNAP_APIRANT_CHANNEL)]' | awk '{print $2}')"
+          PUB_DATE="$(snap info ${{ steps.parse.outputs.snap-name }} | yq '.channels[env(SNAP_ASPIRANT_CHANNEL)]' | awk '{print $2}')"
 
           DATE_REGEX="^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
 
           # @todo(artivis) handle '^' which means that the risk follows the one above
           if ! [[ ${PUB_DATE} =~ ${DATE_REGEX} ]]; then
-            echo "The date '${PUB_DATE}' on channel '${SNAP_APIRANT_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
+            echo "The date '${PUB_DATE}' on channel '${SNAP_ASPIRANT_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
             exit 1
           fi
 
-          echo "Channel '${SNAP_APIRANT_CHANNEL}' publication date: ${PUB_DATE}"
+          echo "Channel '${SNAP_ASPIRANT_CHANNEL}' publication date: ${PUB_DATE}"
 
           echo "snap-aspirant-pub-date=${PUB_DATE}" >> "$GITHUB_OUTPUT"
 
@@ -166,6 +166,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAP_TARGET_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-target }}"
+          SNAP_ASPIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
         run: |
           search_issue="$(gh issue --repo ${{ github.repository }} list --state open \
             --search '${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }} in:title' --json number)"
@@ -182,14 +183,14 @@ jobs:
             echo -e "## Monitoring report\n\n" \
             "- Author: @${{ github.triggering_actor }}\n" \
             "- Target channel: '${SNAP_TARGET_CHANNEL}'\n" \
-            "- Aspirant channel: '${SNAP_APIRANT_CHANNEL}'\n" \
+            "- Aspirant channel: '${SNAP_ASPIRANT_CHANNEL}'\n" \
             "- Workflow Path: '${{ github.workflow_ref }}'\n\n" \
-            "The snap revision on channel '${SNAP_APIRANT_CHANNEL}' has been pending for more than ${{ inputs.threshold }} days'.\n" \
-            "Please consider promoting '${SNAP_APIRANT_CHANNEL}' to '${SNAP_TARGET_CHANNEL}'.\n\n" \
+            "The snap revision on channel '${SNAP_ASPIRANT_CHANNEL}' has been pending for more than ${{ inputs.threshold }} days'.\n" \
+            "Please consider promoting '${SNAP_ASPIRANT_CHANNEL}' to '${SNAP_TARGET_CHANNEL}'.\n\n" \
             "Workflow details at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             | \
             gh issue --repo ${{ github.repository }} create \
-              --title "[CI] Consider promoting '${SNAP_APIRANT_CHANNEL}' to '${SNAP_TARGET_CHANNEL}'." \
+              --title "[CI] Consider promoting '${SNAP_ASPIRANT_CHANNEL}' to '${SNAP_TARGET_CHANNEL}'." \
               ${extra_args} \
               --body-file -
           else

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -15,7 +15,7 @@ on:
         type: string
       snap-name:
         default: ""
-        description: The Snap name.
+        description: The snap name.
         required: false
         type: string
       snap-risk-aspirant:
@@ -82,12 +82,12 @@ jobs:
           )
 
           for file in "${valid_paths[@]}"; do
-            if [[ -f "$file" ]]; then
-              yaml_path="$file"
+            if [ -f "${file}" ]; then
+              yaml_path="${file}"
             fi
           done
 
-          if [[ -z "${yaml_path}" ]]; then
+          if [ -z "${yaml_path}" ]; then
             echo "No snapcraft.yaml found"
             exit 1
           fi

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -51,9 +51,6 @@ jobs:
       issues: write
     steps:
 
-      - name: Install dependencies
-        run: sudo snap install yq
-
       - name: Check snap name input
         if: "${{ inputs.snap-name != '' }}"
         run: echo "snap-name=${{ inputs.snap-name }}" >> "$GITHUB_OUTPUT"
@@ -63,6 +60,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: '${{ inputs.git-ref }}'
+
+      - name: Install dependencies
+        if: "${{ inputs.snap-name == '' }}"
+        run: sudo snap install yq
 
       - name: Find and parse snapcraft.yaml to retrieve the name
         if: "${{ inputs.snap-name == '' }}"

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -138,7 +138,7 @@ jobs:
 
           echo "snap-aspirant-pub-date=${PUB_DATE}" >> "$GITHUB_OUTPUT"
 
-      - name: Compare publication date to threshold
+      - name: Compare aspirant publication date to threshold
         if: steps.revision.outputs.is-newer == '1'
         id: compare
         run: |

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -3,9 +3,19 @@ name: channel-risk-sync-monitor
 on:
   workflow_call:
     inputs:
+      git-ref:
+        default: '${{ github.ref }}'
+        description: The branch to checkout.
+        required: false
+        type: string
       issue-assignee:
         default: ''
         description: The issue assignee in the form '@name'.
+        required: false
+        type: string
+      snap-name:
+        default: ""
+        description: The Snap name.
         required: false
         type: string
       snap-risk-aspirant:
@@ -44,7 +54,18 @@ jobs:
       - name: Install dependencies
         run: sudo snap install yq
 
+      - name: Check snap name input
+        if: "${{ inputs.snap-name != '' }}"
+        run: echo "snap-name=${{ inputs.snap-name }}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: "${{ inputs.snap-name == '' }}"
+        uses: actions/checkout@v4
+        with:
+          ref: '${{ inputs.git-ref }}'
+
       - name: Find and parse snapcraft.yaml to retrieve the name
+        if: "${{ inputs.snap-name == '' }}"
         id: parse
         env:
           project_root: ${{ inputs.snapcraft-source-subdir }}

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -118,7 +118,7 @@ jobs:
             echo "is-newer=0" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Get the revision publication date
+      - name: Get the revision publication date on the aspirant snap track
         if: steps.revision.outputs.is-newer == '1'
         id: date
         env:

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -91,7 +91,7 @@ jobs:
 
           # @todo(artivis) handle '^' which means that the risk follows the one above
           if ! [[ ${PUB_DATE} =~ ${DATE_REGEX} ]]; then
-            "The date '${PUB_DATE}' on channel '${SNAP_TARGET_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
+            echo "The date '${PUB_DATE}' on channel '${SNAP_TARGET_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
             exit 1
           fi
 
@@ -102,7 +102,7 @@ jobs:
           PUB_DATE="$(snap info ${SNAP_NAME} | yq '.channels[env(SNAP_APIRANT_CHANNEL)]' | awk '{print $2}')"
 
           if ! [[ ${PUB_DATE} =~ ${DATE_REGEX} ]]; then
-            "The date '${PUB_DATE}' on channel '${SNAP_TARGET_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
+            echo "The date '${PUB_DATE}' on channel '${SNAP_TARGET_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
             exit 1
           fi
 

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -107,7 +107,7 @@ jobs:
           SNAP_TARGET_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-target }}"
         run: |
           target_rev=$(snap info ${{ steps.parse.outputs.snap-name }} | yq '.channels[env(SNAP_TARGET_CHANNEL)]' | awk '{gsub(/[()]/, ""); print $3}')
-          aspirant_rev=$(snap info ${{ steps.parse.outputs.snap-name }} | yq '.channels[env(SNAP_APIRANT_CHANNEL)]' | awk '{gsub(/[()]/, ""); print $3}')
+          aspirant_rev=$(snap info ${{ steps.parse.outputs.snap-name }} | yq '.channels[env(SNAP_ASPIRANT_CHANNEL)]' | awk '{gsub(/[()]/, ""); print $3}')
 
           if (( ${aspirant_rev} > ${target_rev} )); then
             echo "The revision on channel '${SNAP_APIRANT_CHANNEL}'"\

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -1,0 +1,175 @@
+name: channel-risk-sync-monitor
+
+on:
+  workflow_call:
+    inputs:
+      issue-assignee:
+        default: ''
+        description: The issue assignee in the form '@name'.
+        required: false
+        type: string
+      snap-risk-aspirant:
+        default: candidate
+        description: Snap Store channel risk used as aspirant.
+        required: false
+        type: string
+      snap-risk-target:
+        default: stable
+        description: Snap Store channel risk used as reference.
+        required: false
+        type: string
+      snap-track:
+        default: latest
+        description: Snap Store channel track to monitor.
+        required: false
+        type: string
+      snapcraft-source-subdir:
+        default: "."
+        description: The directory of the snapcraft project.
+        required: false
+        type: string
+      threshold:
+        default: 10
+        description: The threshold to trigger the issue (in days).
+        required: false
+        type: number
+
+jobs:
+  compare:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      issues: write
+    steps:
+
+      - name: Install dependencies
+        run: sudo snap install yq
+
+      - name: Find and parse snapcraft.yaml to retrieve the name
+        id: parse
+        env:
+          project_root: ${{ inputs.snapcraft-source-subdir }}
+        run: |
+          # If no project path is specified, default to top-level of repo
+          project_root="${project_root:-.}"
+
+          valid_paths=(
+            "${project_root}/.snapcraft.yaml"
+            "${project_root}/build-aux/snap/snapcraft.yaml"
+            "${project_root}/snap/snapcraft.yaml"
+            "${project_root}/snapcraft.yaml"
+          )
+
+          for file in "${valid_paths[@]}"; do
+            if [[ -f "$file" ]]; then
+              yaml_path="$file"
+            fi
+          done
+
+          if [[ -z "${yaml_path}" ]]; then
+            echo "No snapcraft.yaml found"
+            exit 1
+          fi
+
+          name="$(yq -r '.name' ${yaml_path})"
+
+          if [ -z "${name}" ]; then exit 1; fi
+
+          echo "Found snap name '${name}'."
+
+          echo "snap-name=${name}" >> "$GITHUB_OUTPUT"
+
+      - name: Get the snap publication dates
+        id: dates
+        env:
+          SNAP_APIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
+          SNAP_NAME: "${{ steps.parse.outputs.snap-name }}"
+          SNAP_TARGET_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-target }}"
+        run: |
+          PUB_DATE="$(snap info ${SNAP_NAME} | yq '.channels[env(SNAP_TARGET_CHANNEL)]' | awk '{print $2}')"
+
+          DATE_REGEX="^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
+
+          # @todo(artivis) handle '^' which means that the risk follows the one above
+          if ! [[ ${PUB_DATE} =~ ${DATE_REGEX} ]]; then
+            "The date '${PUB_DATE}' on channel '${SNAP_TARGET_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
+            exit 1
+          fi
+
+          echo "Channel '${SNAP_TARGET_CHANNEL}' publish date: ${PUB_DATE}"
+
+          echo "snap-target-pub-date=${PUB_DATE}" >> "$GITHUB_OUTPUT"
+
+          PUB_DATE="$(snap info ${SNAP_NAME} | yq '.channels[env(SNAP_APIRANT_CHANNEL)]' | awk '{print $2}')"
+
+          if ! [[ ${PUB_DATE} =~ ${DATE_REGEX} ]]; then
+            "The date '${PUB_DATE}' on channel '${SNAP_TARGET_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
+            exit 1
+          fi
+
+          echo "Channel '${SNAP_APIRANT_CHANNEL}' publish date: ${PUB_DATE}"
+
+          echo "snap-aspirant-pub-date=${PUB_DATE}" >> "$GITHUB_OUTPUT"
+
+      - name: Compare publication dates
+        id: compare
+        env:
+          SNAP_APIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
+          SNAP_ASPIRANT_PUB_DATE: "${{ steps.dates.outputs.snap-aspirant-pub-date }}"
+          SNAP_TARGET_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-target }}"
+          SNAP_TARGET_PUB_DATE: "${{ steps.dates.outputs.snap-target-pub-date }}"
+          THRESHOLD: ${{ inputs.threshold }}
+        run: |
+
+          # Convert the dates to seconds since epoch
+          SNAP_ASPIRANT_PUB_DATE_SECONDS=$(date -d "${SNAP_ASPIRANT_PUB_DATE}" +%s)
+          SNAP_TARGET_PUB_DATE_SECONDS=$(date -d "${SNAP_TARGET_PUB_DATE}" +%s)
+
+          # Calculate the difference in days
+          DIFF_SECS=$((SNAP_ASPIRANT_PUB_DATE_SECONDS - SNAP_TARGET_PUB_DATE_SECONDS))
+          DIFF_DAYS=$((DIFF_SECS / 86400))
+
+          # Compare the difference in days to the threshold
+          if (( ${DIFF_DAYS} >= ${THRESHOLD} )); then
+            echo "The channel '${SNAP_TARGET_CHANNEL}'"\
+            "is outdated compared to '${SNAP_APIRANT_CHANNEL}'"\
+            "(${DIFF_DAYS} >= ${THRESHOLD})."
+            echo "is-outdated=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-outdated=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open issue
+        if: steps.compare.outputs.is-outdated == '1'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNAP_APIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
+          SNAP_TARGET_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-target }}"
+        run: |
+          search_issue="$(gh issue --repo ${{ github.repository }} list --state open \
+            --search '${SNAP_APIRANT_CHANNEL} in:title' --json number)"
+
+          if [[ ! "${search_issue}" =~ "number" ]]; then
+
+            echo "Creating a new issue."
+
+            extra_args=""
+            if [ ! -z "${{ inputs.issue-assignee }}" ]; then
+              extra_args="${extra_args} --assignee ${{ inputs.issue-assignee }}"
+            fi
+
+            echo -e "## Monitoring report\n\n" \
+            "- Author: @${{ github.triggering_actor }}\n" \
+            "- Target channel: '${SNAP_TARGET_CHANNEL}'\n" \
+            "- Aspirant channel: '${SNAP_APIRANT_CHANNEL}'\n" \
+            "- Workflow Path: '${{ github.workflow_ref }}'\n\n" \
+            "The channel '${SNAP_TARGET_CHANNEL}' is outdated compared to '${SNAP_APIRANT_CHANNEL}'.\n" \
+            "Please consider promoting the snap.\n\n" \
+            "Workflow details at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            | \
+            gh issue --repo ${{ github.repository }} create \
+              --title "[CI] Consider promoting '${SNAP_APIRANT_CHANNEL}' to '${SNAP_TARGET_CHANNEL}'." \
+              ${extra_args} \
+              --body-file -
+          else
+            echo "Issue already opened."
+          fi

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Compare the snap revisions
         id: revision
         env:
-          SNAP_APIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
+          SNAP_ASPIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
           SNAP_TARGET_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-target }}"
         run: |
           target_rev=$(snap info ${{ steps.parse.outputs.snap-name }} | yq '.channels[env(SNAP_TARGET_CHANNEL)]' | awk '{gsub(/[()]/, ""); print $3}')

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -110,7 +110,7 @@ jobs:
           aspirant_rev=$(snap info ${{ steps.parse.outputs.snap-name }} | yq '.channels[env(SNAP_ASPIRANT_CHANNEL)]' | awk '{gsub(/[()]/, ""); print $3}')
 
           if (( ${aspirant_rev} > ${target_rev} )); then
-            echo "The revision on channel '${SNAP_APIRANT_CHANNEL}'"\
+            echo "The revision on channel '${SNAP_ASPIRANT_CHANNEL}'"\
             "is newer than on channel '${SNAP_TARGET_CHANNEL}'"\
             "(${aspirant_rev} > ${target_rev})."
             echo "is-newer=1" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -25,7 +25,7 @@ on:
         type: string
       snapcraft-source-subdir:
         default: "."
-        description: The directory of the snapcraft project.
+        description: The directory of the Snapcraft project.
         required: false
         type: string
       threshold:

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -100,61 +100,62 @@ jobs:
 
           echo "snap-name=${name}" >> "$GITHUB_OUTPUT"
 
-      - name: Get the snap publication dates
-        id: dates
+      - name: Compare the snap revisions
+        id: revision
         env:
           SNAP_APIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
-          SNAP_NAME: "${{ steps.parse.outputs.snap-name }}"
           SNAP_TARGET_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-target }}"
         run: |
-          PUB_DATE="$(snap info ${SNAP_NAME} | yq '.channels[env(SNAP_TARGET_CHANNEL)]' | awk '{print $2}')"
+          target_rev=$(snap info ${{ steps.parse.outputs.snap-name }} | yq '.channels[env(SNAP_TARGET_CHANNEL)]' | awk '{gsub(/[()]/, ""); print $3}')
+          aspirant_rev=$(snap info ${{ steps.parse.outputs.snap-name }} | yq '.channels[env(SNAP_APIRANT_CHANNEL)]' | awk '{gsub(/[()]/, ""); print $3}')
+
+          if (( ${aspirant_rev} > ${target_rev} )); then
+            echo "The revision on channel '${SNAP_APIRANT_CHANNEL}'"\
+            "is newer than on channel '${SNAP_TARGET_CHANNEL}'"\
+            "(${aspirant_rev} > ${target_rev})."
+            echo "is-newer=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-newer=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get the revision publication date
+        if: steps.revision.outputs.is-newer == '1'
+        id: date
+        env:
+          SNAP_APIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
+        run: |
+          PUB_DATE="$(snap info ${{ steps.parse.outputs.snap-name }} | yq '.channels[env(SNAP_APIRANT_CHANNEL)]' | awk '{print $2}')"
 
           DATE_REGEX="^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
 
           # @todo(artivis) handle '^' which means that the risk follows the one above
           if ! [[ ${PUB_DATE} =~ ${DATE_REGEX} ]]; then
-            echo "The date '${PUB_DATE}' on channel '${SNAP_TARGET_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
+            echo "The date '${PUB_DATE}' on channel '${SNAP_APIRANT_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
             exit 1
           fi
 
-          echo "Channel '${SNAP_TARGET_CHANNEL}' publish date: ${PUB_DATE}"
-
-          echo "snap-target-pub-date=${PUB_DATE}" >> "$GITHUB_OUTPUT"
-
-          PUB_DATE="$(snap info ${SNAP_NAME} | yq '.channels[env(SNAP_APIRANT_CHANNEL)]' | awk '{print $2}')"
-
-          if ! [[ ${PUB_DATE} =~ ${DATE_REGEX} ]]; then
-            echo "The date '${PUB_DATE}' on channel '${SNAP_TARGET_CHANNEL}' does not match the expect format 'YYYY-MM-DD'."
-            exit 1
-          fi
-
-          echo "Channel '${SNAP_APIRANT_CHANNEL}' publish date: ${PUB_DATE}"
+          echo "Channel '${SNAP_APIRANT_CHANNEL}' publication date: ${PUB_DATE}"
 
           echo "snap-aspirant-pub-date=${PUB_DATE}" >> "$GITHUB_OUTPUT"
 
-      - name: Compare publication dates
+      - name: Compare publication date to threshold
+        if: steps.revision.outputs.is-newer == '1'
         id: compare
-        env:
-          SNAP_APIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
-          SNAP_ASPIRANT_PUB_DATE: "${{ steps.dates.outputs.snap-aspirant-pub-date }}"
-          SNAP_TARGET_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-target }}"
-          SNAP_TARGET_PUB_DATE: "${{ steps.dates.outputs.snap-target-pub-date }}"
-          THRESHOLD: ${{ inputs.threshold }}
         run: |
 
           # Convert the dates to seconds since epoch
-          SNAP_ASPIRANT_PUB_DATE_SECONDS=$(date -d "${SNAP_ASPIRANT_PUB_DATE}" +%s)
-          SNAP_TARGET_PUB_DATE_SECONDS=$(date -d "${SNAP_TARGET_PUB_DATE}" +%s)
+          SNAP_ASPIRANT_PUB_DATE_SECONDS=$(date -d "${{ steps.date.outputs.snap-aspirant-pub-date }}" +%s)
+          TODAY_SECONDS=$(date +%s)
 
           # Calculate the difference in days
-          DIFF_SECS=$((SNAP_ASPIRANT_PUB_DATE_SECONDS - SNAP_TARGET_PUB_DATE_SECONDS))
+          DIFF_SECS=$((TODAY_SECONDS - SNAP_ASPIRANT_PUB_DATE_SECONDS))
           DIFF_DAYS=$((DIFF_SECS / 86400))
 
           # Compare the difference in days to the threshold
-          if (( ${DIFF_DAYS} >= ${THRESHOLD} )); then
-            echo "The channel '${SNAP_TARGET_CHANNEL}'"\
-            "is outdated compared to '${SNAP_APIRANT_CHANNEL}'"\
-            "(${DIFF_DAYS} >= ${THRESHOLD})."
+          if (( ${DIFF_DAYS} >= ${{ inputs.threshold }} )); then
+            echo "The revision published on '${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}'"\
+            "is waiting for promotion"\
+            "(${DIFF_DAYS} > ${{ inputs.threshold }})."
             echo "is-outdated=1" >> "$GITHUB_OUTPUT"
           else
             echo "is-outdated=0" >> "$GITHUB_OUTPUT"
@@ -164,11 +165,10 @@ jobs:
         if: steps.compare.outputs.is-outdated == '1'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SNAP_APIRANT_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }}"
           SNAP_TARGET_CHANNEL: "${{ inputs.snap-track }}/${{ inputs.snap-risk-target }}"
         run: |
           search_issue="$(gh issue --repo ${{ github.repository }} list --state open \
-            --search '${SNAP_APIRANT_CHANNEL} in:title' --json number)"
+            --search '${{ inputs.snap-track }}/${{ inputs.snap-risk-aspirant }} in:title' --json number)"
 
           if [[ ! "${search_issue}" =~ "number" ]]; then
 
@@ -184,8 +184,8 @@ jobs:
             "- Target channel: '${SNAP_TARGET_CHANNEL}'\n" \
             "- Aspirant channel: '${SNAP_APIRANT_CHANNEL}'\n" \
             "- Workflow Path: '${{ github.workflow_ref }}'\n\n" \
-            "The channel '${SNAP_TARGET_CHANNEL}' is outdated compared to '${SNAP_APIRANT_CHANNEL}'.\n" \
-            "Please consider promoting the snap.\n\n" \
+            "The snap revision on channel '${SNAP_APIRANT_CHANNEL}' has been pending for more than ${{ inputs.threshold }} days'.\n" \
+            "Please consider promoting '${SNAP_APIRANT_CHANNEL}' to '${SNAP_TARGET_CHANNEL}'.\n\n" \
             "Workflow details at: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             | \
             gh issue --repo ${{ github.repository }} create \

--- a/README.md
+++ b/README.md
@@ -259,14 +259,17 @@ It provides a `script-get-upstream-version` script that retrieve the latest tag 
 
 ### The channel-risk-sync-monitor workflow
 
-The [channel-risk-sync-monitor](.github/workflows/channel-risk-sync-monitor.yaml) workflow compares the publications dates of a snap on two risk levels of a given track (e.g. `latest/candidate` vs `latest/stable`).
-If the publication date difference is greater than or equal to a threshold, it opens an issue.
+The [channel-risk-sync-monitor](.github/workflows/channel-risk-sync-monitor.yaml) workflow compares the publication date of a snap revision on a given risk level to that of 'today'.
+If the difference is greater than or equal to a threshold,
+it opens an issue.
 
 #### Options
 
 | Option | Default Value | Description | Required |
 |---|---|---|---|
+| `git-ref` | ${{ github.ref }} | The branch to checkout. | false |
 | `issue-assignee` | '' | Whom to assign the issue to. | false |
+| `snap-name` | '' | The snap name. | false |
 | `snap-risk-aspirant` | 'candidate' | The risk level to compare. | false |
 | `snap-risk-target` | 'stable' | The risk level target for the comparison. | false |
 | `snap-track` | 'latest' | The track to use for the comparison. | false |

--- a/README.md
+++ b/README.md
@@ -271,4 +271,4 @@ If the publication date difference is greater or equal to a threshold, it opens 
 | `snap-risk-target` | 'stable' | The risk level target for the comparison. | false |
 | `snap-track` | 'latest' | The track to use for the comparison. | false |
 | `snapcraft-source-subdir` | ' . ' | The directory of the snapcraft project. | false |
-| `threshold` | '10' | The threshold to trigger the issue (in days) | false |
+| `threshold` | '10' | The threshold to trigger the issue (in days). | false |

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ It provides a `script-get-upstream-version` script that retrieve the latest tag 
 ### The channel-risk-sync-monitor workflow
 
 The [channel-risk-sync-monitor](.github/workflows/channel-risk-sync-monitor.yaml) workflow compares the publications dates of a snap on two risk levels of a given track (e.g. `latest/candidate` vs `latest/stable`).
-If the publication date difference is greater or equal to a threshold, it opens an issue.
+If the publication date difference is greater than or equal to a threshold, it opens an issue.
 
 #### Options
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Robotics Actions Workflows
 
-This repository hosts a collection of [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) for building, testing & releasing robotics snaps.
+This repository hosts a collection of [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) for building, testing & releasing snaps.
 
 These workflows are intended to be re-used in github actions building snaps.
 They implement an opinionated workflow to build, test & release snaps.
@@ -45,6 +45,7 @@ The reusable workflows are:
 - [promote.yaml](.github/workflows/promote.yaml) - the workflow to promote the snap on the store.
 - [generic-upstream-monitor.yaml](.github/workflows/generic-upstream-monitor.yaml) - the workflow to monitor new upstream versions.
 - [upstream-gh-tag-monitor.yaml](.github/workflows/upstream-gh-tag-monitor.yaml) - the workflow to monitor new tag on an upstream repository.
+- [channel-risk-sync-monitor.yaml](.github/workflows/channel-risk-sync-monitor.yaml) - the workflow to monitor the promotion from a channel risk to another.
 
 ### General notes
 
@@ -255,3 +256,19 @@ It provides a `script-get-upstream-version` script that retrieve the latest tag 
 | `issue-assignee` | '' | Whom to assign the issue to. | false |
 | `snapcraft-source-subdir` | ' . ' | The directory of the snapcraft project. | false |
 | `source-repo` | '' | The upstream repository to monitor in 'org/repo' form. | true |
+
+### The channel-risk-sync-monitor workflow
+
+The [channel-risk-sync-monitor](.github/workflows/channel-risk-sync-monitor.yaml) workflow compares the publications dates of a snap on two risk levels of a given track (e.g. `latest/candidate` vs `latest/stable`).
+If the publication date difference is greater or equal to a threshold, it opens an issue.
+
+#### Options
+
+| Option | Default Value | Description | Required |
+|---|---|---|---|
+| `issue-assignee` | '' | Whom to assign the issue to. | false |
+| `snap-risk-aspirant` | 'candidate' | The risk level to compare. | false |
+| `snap-risk-target` | 'stable' | The risk level target for the comparison. | false |
+| `snap-track` | 'latest' | The track to use for the comparison. | false |
+| `snapcraft-source-subdir` | ' . ' | The directory of the snapcraft project. | false |
+| `threshold` | '10' | The threshold to trigger the issue (in days) | false |


### PR DESCRIPTION
Add a workflow to compare the publication dates of two risk levels (e.g. `latest/candidate` vs `latest/stable`) and open an issue in case the difference is greater than a threshold.