### PR TITLE
remove redundant track

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -98,4 +98,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapstore-login }}
         with:
           snap: ${{ matrix.snap }}
-          release: ${{ inputs.snap-track }}/${{ steps.set-snap-channel.outputs.snap-channel }}
+          release: ${{ steps.set-snap-channel.outputs.snap-channel }}


### PR DESCRIPTION
The snap track is already defined in the set snap channel function and it defaults to latest.
THis PR removes the redundant snap-track variable at publishing.
This is to solve issues such as https://github.com/canonical/cos-registration-agent/actions/runs/13839590158/job/38723674381.