### PR TITLE
Fix post hardening

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: String to JSON list
         id: string-to-json
-        uses: ./string-to-json
+        uses: canonical/robotics-actions-workflows/string-to-json@main
         with:
           string: ${{ inputs.runs-on }}
 
@@ -60,7 +60,7 @@ jobs:
     steps:
       - name: String to JSON list
         id: string-to-json
-        uses: ./string-to-json
+        uses: canonical/robotics-actions-workflows/string-to-json@main
         with:
           string: ${{ inputs.snapcraft-source-subdir }}
 

--- a/.github/workflows/bump-snap-version.yaml
+++ b/.github/workflows/bump-snap-version.yaml
@@ -34,9 +34,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
-
 concurrency:
   group: bump-snap-version-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/bump-snap-version.yaml
+++ b/.github/workflows/bump-snap-version.yaml
@@ -166,7 +166,7 @@ jobs:
       - name: Parse snapcraft metadata
         if: steps.find-issue.outputs.version != '' && steps.check-existing-pr.outputs.skip != 'true'
         id: parse
-        uses: ./parse-snapcraft-metadata
+        uses: canonical/robotics-actions-workflows/parse-snapcraft-metadata@main
         with:
           snapcraft-source-subdir: ${{ inputs.snapcraft-source-subdir }}
 

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Parse snapcraft metadata
         if: "${{ inputs.snap-name == '' }}"
         id: parse-metadata
-        uses: ./parse-snapcraft-metadata
+        uses: canonical/robotics-actions-workflows/parse-snapcraft-metadata@main
         with:
           snapcraft-source-subdir: ${{ inputs.snapcraft-source-subdir }}
 

--- a/.github/workflows/channel-risk-sync-monitor.yaml
+++ b/.github/workflows/channel-risk-sync-monitor.yaml
@@ -44,9 +44,6 @@ on:
         required: false
         type: number
 
-permissions:
-  contents: read
-
 concurrency:
   group: channel-risk-monitor-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/generic-upstream-monitor.yaml
+++ b/.github/workflows/generic-upstream-monitor.yaml
@@ -27,9 +27,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
-
 concurrency:
   group: upstream-monitor-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/generic-upstream-monitor.yaml
+++ b/.github/workflows/generic-upstream-monitor.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Parse snapcraft metadata
         id: parse
-        uses: ./parse-snapcraft-metadata
+        uses: canonical/robotics-actions-workflows/parse-snapcraft-metadata@main
         with:
           snapcraft-source-subdir: ${{ inputs.snapcraft-source-subdir }}
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Parse snapcraft metadata
         if: inputs.snap == ''
         id: parse-metadata
-        uses: ./parse-snapcraft-metadata
+        uses: canonical/robotics-actions-workflows/parse-snapcraft-metadata@main
         with:
           snapcraft-source-subdir: ${{ inputs.snapcraft-source-subdir }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: String to JSON list
         id: string-to-json
-        uses: ./string-to-json
+        uses: canonical/robotics-actions-workflows/string-to-json@main
         with:
           string: ${{ inputs.runs-on }}
 

--- a/.github/workflows/upstream-gh-tag-monitor.yaml
+++ b/.github/workflows/upstream-gh-tag-monitor.yaml
@@ -23,9 +23,6 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: read
-
 concurrency:
   group: gh-tag-monitor-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
Fixes following up #31 

In a reusable workflow step, relative paths resolve to the caller's checked-out workspace. So we would have to either checkout the actions (e.g. [actions/checkout](https://github.com/actions/checkout)) or, simpler, use the full format as in this PR.

As for permissions, they can only restrict, not escalate.