### PR TITLE
[hermes-agent] build: pin action-build to v1.3.0 commit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,7 +80,7 @@ jobs:
           ref: '${{ inputs.git-ref }}'
 
       - name: Build snap
-        uses: canonical/action-build@ea14cdeb353272f75977040488ca191880509a8c # v1.1.0
+        uses: canonical/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
         id: build-snap
         env:
           SNAPCRAFT_BUILD_INFO: 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,7 +80,7 @@ jobs:
           ref: '${{ inputs.git-ref }}'
 
       - name: Build snap
-        uses: canonical/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1
+        uses: canonical/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
         id: build-snap
         env:
           SNAPCRAFT_BUILD_INFO: 1


### PR DESCRIPTION
[hermes-agent]

## Summary
- pin `canonical/action-build` in `.github/workflows/build.yaml` to commit `3bdaa03e1ba6bf59a65f84a751d943d549a54e79`
- this commit is exactly **`canonical/action-build` `v1.3.0`**
- replace the older pinned commit `ea14cdeb353272f75977040488ca191880509a8c` (`v1.1.0`)

## Why
Recent downstream snap builds on Ubuntu 24.04 runners have been failing during Snapcraft base instance creation with:

- `craft-providers error: A network related operation failed in a context of no network access`

`action-build` `v1.3.0` includes the Ubuntu 24.04/LXD network fix path (notably the LXD iptables handling change introduced in `canonical/action-build`) that avoids the broken networking behavior seen with the older pin.

## Validation
- verified that git tag `v1.3.0` in `canonical/action-build` points to commit `3bdaa03e1ba6bf59a65f84a751d943d549a54e79`
- this PR remains a minimal SHA bump + clarity update in the reusable `build` workflow
