### PR TITLE
[hermes-agent] publish: pin action-publish to v1.2.0 commit

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -109,7 +109,7 @@ jobs:
           echo "snap-channel=${SNAP_CHANNEL}" >> "$GITHUB_OUTPUT"
 
       - name: Publish snap
-        uses: canonical/action-publish@f1879414dc5500e02a36f3d715bca6ddd438c913 # v1.0.2
+        uses: canonical/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapstore-login }}
         with:


### PR DESCRIPTION
[hermes-agent]

## Summary
- Repin `canonical/action-publish` in `.github/workflows/publish.yaml`
- From `f1879414dc5500e02a36f3d715bca6ddd438c913` (`v1.0.2`)
- To `214b86e5ca036ead1668c79afb81e550e6c54d40` (`v1.2.0`)

## Why
`ubuntu-robotics/netbird_snap` publish jobs failed in run `29819577772` https://github.com/ubuntu-robotics/netbird_snap/actions/runs/29819577772/job/88600839888 with:
- `login_data is empty`

That run consumed this reusable workflow after it pinned `action-publish` to `v1.0.2`.
The older action path regressed this caller setup, while previous successful runs used the newer `v1` line (resolving to `v1.2.0`).

## Validation
- Local workflow lint (`./scripts/lint.sh`) passes (`actionlint` + `shellcheck`).
- Change is minimal and scoped to publish action pin only.

## Impact
Restores snap publish compatibility for callers using `SNAPCRAFT_STORE_CREDENTIALS` in current workflows (including netbird_snap PR CI).
